### PR TITLE
feat: Add GitHub Action for Docker image publishing

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,193 @@
+name: Docker Publish
+
+on:
+  push:
+    tags:
+      - 'v*' # Trigger on version tags like v1.0.0
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read    # To read repository content
+      packages: write   # To push packages to GitHub Container Registry
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
+        with:
+          java-version: '8' # Assuming Java 8, adjust if needed
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Set up Node.js 18
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18' # Assuming Node.js 18 for pnpm and UI build, adjust if needed
+
+      - name: Install pnpm
+        run: npm i -g pnpm
+
+      - name: Build Java project (generate JARs)
+        run: mvn -U clean install -DskipTests
+        # This assumes orion-visor-launch.jar will be in orion-visor-launch/target/
+
+      - name: Build UI project (generate dist)
+        # Assuming the UI project is in a subdirectory named 'orion-visor-ui'
+        # If your UI project is at the root, remove 'working-directory'
+        # and adjust paths in later copy steps accordingly.
+        working-directory: ./orion-visor-ui
+        run: |
+          pnpm install
+          pnpm build
+        # This assumes 'dist' directory will be created in ./orion-visor-ui/dist
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta # Giving an ID to this step to reference its outputs later
+        uses: docker/metadata-action@v5
+        with:
+          images: | # Define base image names for metadata generation
+            orion-visor-adminer
+            orion-visor-e2e
+            orion-visor-guacd
+            orion-visor-mysql
+            orion-visor-redis
+            orion-visor-service
+            orion-visor-ui
+          tags: | # Define how tags are generated
+            type=semver,pattern={{version}} # Main strategy: git tag v1.2.3 will produce tag 1.2.3
+            type=semver,pattern={{major}}.{{minor}} # e.g., v1.2.3 -> 1.2
+            type=semver,pattern={{major}} # e.g., v1.2.3 -> 1
+
+      # --- Build and push generic images ---
+
+      - name: Build and push orion-visor-adminer
+        uses: docker/build-push-action@v5
+        with:
+          context: ./docker/adminer
+          file: ./docker/adminer/Dockerfile
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/orion-visor-adminer:${{ steps.meta.outputs.version }}
+            ghcr.io/${{ github.repository_owner }}/orion-visor-adminer:${{ steps.meta.outputs.version }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # platforms: linux/amd64,linux/arm64
+
+      - name: Build and push orion-visor-e2e
+        uses: docker/build-push-action@v5
+        with:
+          context: ./docker/e2e
+          file: ./docker/e2e/Dockerfile
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/orion-visor-e2e:${{ steps.meta.outputs.version }}
+            ghcr.io/${{ github.repository_owner }}/orion-visor-e2e:${{ steps.meta.outputs.version }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # platforms: linux/amd64,linux/arm64
+
+      - name: Build and push orion-visor-guacd
+        uses: docker/build-push-action@v5
+        with:
+          context: ./docker/guacd
+          file: ./docker/guacd/Dockerfile
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/orion-visor-guacd:${{ steps.meta.outputs.version }}
+            ghcr.io/${{ github.repository_owner }}/orion-visor-guacd:${{ steps.meta.outputs.version }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # platforms: linux/amd64,linux/arm64
+
+      - name: Build and push orion-visor-mysql
+        uses: docker/build-push-action@v5
+        with:
+          context: ./docker/mysql
+          file: ./docker/mysql/Dockerfile
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/orion-visor-mysql:${{ steps.meta.outputs.version }}
+            ghcr.io/${{ github.repository_owner }}/orion-visor-mysql:${{ steps.meta.outputs.version }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # platforms: linux/amd64,linux/arm64
+
+      - name: Build and push orion-visor-redis
+        uses: docker/build-push-action@v5
+        with:
+          context: ./docker/redis
+          file: ./docker/redis/Dockerfile
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/orion-visor-redis:${{ steps.meta.outputs.version }}
+            ghcr.io/${{ github.repository_owner }}/orion-visor-redis:${{ steps.meta.outputs.version }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # platforms: linux/amd64,linux/arm64
+
+      # --- Build and push orion-visor-service (requires pre-built JAR) ---
+
+      - name: Prepare service build context
+        run: |
+          echo "Copying JAR to service context..."
+          # ls -l ./orion-visor-launch/target/ # Optional: list files for debugging
+          cp ./orion-visor-launch/target/orion-visor-launch.jar ./docker/service/orion-visor-launch.jar
+          echo "Copied JAR."
+          # ls -l ./docker/service/ # Optional: list files for debugging
+
+      - name: Build and push orion-visor-service
+        uses: docker/build-push-action@v5
+        with:
+          context: ./docker/service
+          file: ./docker/service/Dockerfile
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/orion-visor-service:${{ steps.meta.outputs.version }}
+            ghcr.io/${{ github.repository_owner }}/orion-visor-service:${{ steps.meta.outputs.version }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # platforms: linux/amd64,linux/arm64
+        # run: rm ./docker/service/orion-visor-launch.jar # Optional cleanup
+
+      # --- Build and push orion-visor-ui (requires pre-built dist directory) ---
+
+      - name: Prepare UI build context
+        run: |
+          echo "Copying UI dist to UI context..."
+          # ls -l ./orion-visor-ui/ # Optional: list files for debugging
+          # Ensure the source dist path is correct based on your UI build output
+          cp -r ./orion-visor-ui/dist ./docker/ui/dist
+          echo "Copied UI dist."
+          # ls -l ./docker/ui/ # Optional: list files for debugging
+
+      - name: Build and push orion-visor-ui
+        uses: docker/build-push-action@v5
+        with:
+          context: ./docker/ui # dist/ directory should now be here
+          file: ./docker/ui/Dockerfile
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/orion-visor-ui:${{ steps.meta.outputs.version }}
+            ghcr.io/${{ github.repository_owner }}/orion-visor-ui:${{ steps.meta.outputs.version }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # platforms: linux/amd64,linux/arm64 # Uncomment for multi-platform builds
+        # Optional: Clean up the copied dist directory after build
+        # run: rm -rf ./docker/ui/dist


### PR DESCRIPTION
This commit introduces a GitHub Action workflow to automate the building and pushing of Docker images for various services within the project.

The workflow triggers on pushes to tags matching 'v*' (e.g., v1.0.0) and can also be manually dispatched.

It performs the following main steps:
1. Sets up Java and Node.js environments.
2. Compiles the Java backend (service) and builds the frontend UI.
3. Logs into Docker Hub and GitHub Container Registry (GHCR).
4. Extracts version information from Git tags.
5. Builds and pushes Docker images for:
   - adminer
   - e2e
   - guacd
   - mysql
   - redis
   - service (using the compiled JAR)
   - ui (using the built UI assets)

Images are tagged with the version derived from the Git tag and pushed to both Docker Hub (requires DOCKERHUB_USERNAME and DOCKERHUB_TOKEN secrets) and GHCR (uses GITHUB_TOKEN).